### PR TITLE
Correct article tags on card subsections to hold more content

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,54 @@
   <div>
     <h2>Characters I love to Hate</h2>
     <section class="container">
-      <article class="card">Dolores Umbridge</article>
-      <article class="card">The Daleks</article>
-      <article class="card">Daisy Buchanan</article>
-      <article class="card">Joffery Baratheon</article>
-      <article class="card">Saruman</article>
-      <article class="card">Bella Swan & Edward Cullen</article>
+      <article class="card">
+        <h5>Dolores Umbridge</h5>
+          <p class="subtitle">subtitle</p>
+          <p class="blurb"></p>
+          <p class="origin">Origin</p>
+          <p class="boo-count">Boos</p>
+          <p class="counter"></p>
+      </article>
+      <article class="card">
+        <h5>The Daleks</h5>
+          <p class="subtitle">subtitle</p>
+          <p class="blurb"></p>
+          <p class="origin">Origin</p>
+          <p class="boo-count">Boos</p>
+          <p class="counter"></p>
+      </article>
+      <article class="card">
+        <h5>Daisy Buchanan</h5>
+          <p class="subtitle">subtitle</p>
+          <p class="blurb"></p>
+          <p class="origin">Origin</p>
+          <p class="boo-count">Boos</p>
+          <p class="counter"></p>
+      </article>
+      <article class="card">
+        <h5>Joffery Baratheon</h5>
+          <p class="subtitle">subtitle</p>
+          <p class="blurb"></p>
+          <p class="origin">Origin</p>
+          <p class="boo-count">Boos</p>
+          <p class="counter"></p>
+      </article>
+      <article class="card">
+        <h5>Saruman</h5>
+          <p class="subtitle">subtitle</p>
+          <p class="blurb"></p>
+          <p class="origin">Origin</p>
+          <p class="boo-count">Boos</p>
+          <p class="counter"></p>
+      </article>
+      <article class="card">
+        <h5>Bella Swan & Edward Cullen</h5>
+          <p class="subtitle">subtitle</p>
+          <p class="blurb"></p>
+          <p class="origin">Origin</p>
+          <p class="boo-count">Boos</p>
+          <p class="counter"></p>
+      </article>
     </section>
   </div>
 </body>

--- a/style.css
+++ b/style.css
@@ -48,8 +48,7 @@ h2 {
   display: flex;
   flex-flow:row wrap;
   justify-content: center;
-  
-  height:
+
 
 }
 
@@ -58,7 +57,7 @@ article {
 
 }
 .card{
-  flex:1;
+  flex:3;
   background: #ffffff;
   padding: 10px;
   box-shadow: 2px,2px,2px,2px;


### PR DESCRIPTION
This PR is to correct the article closing tag alignment. All content on each "card" is now held within the article tag. These create the areas for additional content to be added later. 